### PR TITLE
Add CHANGELOG.md and basic GH actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,22 @@
+name: "Pull Request"
+
+on:
+  pull_request:
+    # The specific activity types are listed here to include "labeled" and "unlabeled"
+    # (which are not included by default for the "pull_request" trigger).
+    # This is needed to allow skipping enforcement of the changelog in PRs with specific labels,
+    # as defined in the (optional) "skipLabels" property of the Changelog Enforcer.
+    types: [ opened, synchronize, reopened, ready_for_review, labeled, unlabeled ]
+    # Means that this runs on PRs to main.
+    branches: [ main ]
+
+jobs:
+
+  # Enforces the update of a changelog file on every pull request
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dangoslen/changelog-enforcer@v3
+        with:
+          skipLabels: skip-changelog
+          missingUpdateErrorMessage: 'You need to either add changes to CHANGELOG.md or use the "skip-changelog" label'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: "Release"
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.4.0
+
+      - name: read version number
+        id: read-version
+        run: |
+          CHANGELOG_VERSION=$(sed '9!d' ./CHANGELOG.md | cut -d'[' -f2 | cut -d']' -f1)
+          echo 'Ignoring version case is "Unreleased"'
+          echo ::set-output name=version::$([[ "$CHANGELOG_VERSION" =~ ^(UNRELEASED|unreleased|Unreleased)$ ]] && echo '' || echo $CHANGELOG_VERSION)
+
+      - name: read changelog content for version number obtained
+        if: ${{ steps.read-version.outputs.version != '' }}
+        id: changelog-reader
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          version: "${{ steps.read-version.outputs.version }}"
+          path: ./CHANGELOG.md
+
+      - name: check for existing release
+        if: ${{ steps.read-version.outputs.version != '' }}
+        id: check-release
+        run: |
+          VERSION=$(git ls-remote --tags origin | grep --fixed-strings ${{ steps.read-version.outputs.version }} || [[ $? == 1 ]] && echo '')
+          MISSING=$([[ -z "$VERSION" ]] && echo 'true' || echo 'false')
+          echo ::set-output name=missing::$MISSING
+
+      - name: create release
+        if: ${{ steps.check-release.outputs.missing == 'true' && steps.read-version.outputs.version != '' }}
+        id: create-release
+        uses: actions/create-release@v1.1.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: "${{ steps.read-version.outputs.version }}"
+          release_name: Blood Pressure Diary v${{ steps.read-version.outputs.version }}
+          body: ${{ steps.changelog-reader.outputs.changes }}
+          draft: false
+          prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). An `Unreleased` section is allowed when changes are being merged but not released yet.
+
+Types of changes: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed` and `Security`.
+
+[//]: # (The latest version must start on line 9. The GitHub Actions of this repo rely on it. You ca use UNRELEASED as the version if you don't want to release.)
+## [0.3.0-alpha]
+### Added
+- CHANGELOG.md
+- `pull_request.yml` action to check PRs for a CHANGELOG.md modification (and potentially lint and test the files later?)
+- `release.yml` action to automatically release upon merge on `main` branch.
+
+## [0.2-alpha]
+### Fixed
+- Fix the score to update on every iteration. 
+
+## [0.1-alpha]
+### Added
+- The basics.


### PR DESCRIPTION
### Added
- CHANGELOG.md
- `pull_request.yml` action to check PRs for a CHANGELOG.md modification (and potentially lint and test the files later?)
- `release.yml` action to automatically release upon merge on `main` branch.